### PR TITLE
generate amino acid parser with Automa.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5
+Automa 0.3
 Compat 0.17.0

--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -96,6 +96,8 @@ export
     compatbits,
     alphabet
 
+import Automa
+import Automa.RegExp: @re_str
 using Compat
 
 include("nucleicacid.jl")

--- a/src/aminoacid.jl
+++ b/src/aminoacid.jl
@@ -23,9 +23,11 @@ Base.convert{T<:Number}(::Type{AminoAcid}, aa::T) = convert(AminoAcid, UInt8(aa)
 # -----------------------
 
 function Base.convert(::Type{AminoAcid}, c::Char)
-    @inbounds aa = c <= '\x7f' ? char_to_aa[Int(c)+1] : AA_INVALID
-    @assert aa != AA_INVALID error("$(c) is not a valid amino acid")
-    return aa
+    aa = tryparse(AminoAcid, c)
+    if isnull(aa)
+        throw(InexactError())
+    end
+    return get(aa)
 end
 
 Base.convert(::Type{Char}, aa::AminoAcid) = aa_to_char[convert(UInt8, aa) + 1]

--- a/src/aminoacid.jl
+++ b/src/aminoacid.jl
@@ -161,18 +161,71 @@ const threeletter_to_aa = Dict(
     "PYL" => AA_O, "SEC" => AA_U,
 )
 
-function Base.parse(::Type{AminoAcid}, s::AbstractString)
-    s′ = strip(s)
-    if length(s′) == 1
-        return convert(AminoAcid, s′[1])
+# Generate an amino acid parser.
+let
+    re = Automa.RegExp
+    function aapat(three, aa)
+        one = convert(Char, aa)
+        pat = re.alt(
+            re.cat([re.alt(lowercase(x), uppercase(x)) for x in three]...),
+            lowercase(one),
+            uppercase(one))
+        pat.actions[:exit] = [Symbol(three)]
+        return pat
     end
-    try
-        return threeletter_to_aa[uppercase(s′)]
-    catch ex
-        if isa(ex, KeyError)
-            error("invalid amino acid string: \"$s\" ")
+    aminoacids = [
+        ("ALA", AA_A),
+        ("ARG", AA_R),
+        ("ASN", AA_N),
+        ("ASP", AA_D),
+        ("CYS", AA_C),
+        ("GLN", AA_Q),
+        ("GLU", AA_E),
+        ("GLY", AA_G),
+        ("HIS", AA_H),
+        ("ILE", AA_I),
+        ("LEU", AA_L),
+        ("LYS", AA_K),
+        ("MET", AA_M),
+        ("PHE", AA_F),
+        ("PRO", AA_P),
+        ("SER", AA_S),
+        ("THR", AA_T),
+        ("TRP", AA_W),
+        ("TYR", AA_Y),
+        ("VAL", AA_V),
+        ("ASX", AA_B),
+        ("XLE", AA_J),
+        ("GLX", AA_Z),
+        ("XAA", AA_X),
+        ("PYL", AA_O),
+        ("SEC", AA_U),
+    ]
+    aa_term = re"\*"
+    aa_term.actions[:exit] = [:Term]
+    aa_gap = re"-"
+    aa_gap.actions[:exit] = [:Gap]
+    whitespaces = re"[ \t\r\n]*"
+    aminoacid = re.cat(
+        whitespaces,
+        re.alt(vcat((aapat(three, aa) for (three, aa) in aminoacids)..., aa_term, aa_gap)...),
+        whitespaces)
+    machine = Automa.compile(aminoacid)
+    actions = Dict(Symbol(three) => :(aa = $(aa)) for (three, aa) in aminoacids)
+    actions[:Term] = :(aa = AA_Term)
+    actions[:Gap]  = :(aa = AA_Gap)
+
+    ctx = Automa.CodeGenContext(checkbounds=false)
+    @eval function Base.parse(::Type{AminoAcid}, data::AbstractString)
+        $(Automa.generate_init_code(ctx, machine))
+        p_end = p_eof = sizeof(data)
+        aa = AA_INVALID
+        $(Automa.generate_exec_code(ctx, machine, actions))
+        if cs != 0
+            throw(ArgumentError("invalid amino acid"))
         end
-        rethrow()
+        @assert aa != AA_INVALID
+        return aa
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -419,6 +419,19 @@ end
 
         @test convert(AminoAcid, 0) === AA_A
         @test convert(AminoAcid, 10) === AA_L
+
+        for (c, aa) in [
+                ('A', AA_A), ('R', AA_R), ('N', AA_N), ('D', AA_D), ('C', AA_C),
+                ('Q', AA_Q), ('E', AA_E), ('G', AA_G), ('H', AA_H), ('I', AA_I),
+                ('L', AA_L), ('K', AA_K), ('M', AA_M), ('F', AA_F), ('P', AA_P),
+                ('S', AA_S), ('T', AA_T), ('W', AA_W), ('Y', AA_Y), ('V', AA_V),
+                ('O', AA_O), ('U', AA_U), ('B', AA_B), ('J', AA_J), ('Z', AA_Z),
+                ('X', AA_X), ('*', AA_Term), ('-', AA_Gap)]
+            @test convert(AminoAcid, c) === convert(AminoAcid, lowercase(c)) == aa
+        end
+        @test_throws InexactError convert(AminoAcid, '\0')
+        @test_throws InexactError convert(AminoAcid, '@')
+        @test_throws InexactError convert(AminoAcid, '亜')
     end
 
     @testset "isvalid" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -546,9 +546,15 @@ end
             for (one, three, aa) in aas
                 @test parse(AminoAcid, one) == aa
                 @test parse(AminoAcid, three) == aa
+                @test parse(AminoAcid, Char(one[1])) == aa
+                @test tryparse(AminoAcid, one) === Nullable(aa)
+                @test tryparse(AminoAcid, three) === Nullable(aa)
+                @test tryparse(AminoAcid, Char(one[1])) === Nullable(aa)
             end
             @test parse(AminoAcid, "*") == AA_Term
             @test parse(AminoAcid, "-") == AA_Gap
+            @test tryparse(AminoAcid, "*") === Nullable(AA_Term)
+            @test tryparse(AminoAcid, "-") === Nullable(AA_Gap)
         end
 
         @testset "Invalid Cases" begin
@@ -556,6 +562,10 @@ end
             @test_throws Exception parse(AminoAcid, "AL")
             @test_throws Exception parse(AminoAcid, "LA")
             @test_throws Exception parse(AminoAcid, "ALAA")
+            @test isnull(tryparse(AminoAcid, ""))
+            @test isnull(tryparse(AminoAcid, "AL"))
+            @test isnull(tryparse(AminoAcid, "LA"))
+            @test isnull(tryparse(AminoAcid, "ALAA"))
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -571,14 +571,20 @@ end
         end
 
         @testset "Invalid Cases" begin
-            @test_throws Exception parse(AminoAcid, "")
-            @test_throws Exception parse(AminoAcid, "AL")
-            @test_throws Exception parse(AminoAcid, "LA")
-            @test_throws Exception parse(AminoAcid, "ALAA")
+            @test_throws ArgumentError parse(AminoAcid, "")
+            @test_throws ArgumentError parse(AminoAcid, "AL")
+            @test_throws ArgumentError parse(AminoAcid, "LA")
+            @test_throws ArgumentError parse(AminoAcid, "ALAA")
+            @test_throws ArgumentError parse(AminoAcid, '\0')
+            @test_throws ArgumentError parse(AminoAcid, '@')
+            @test_throws ArgumentError parse(AminoAcid, '亜')
             @test isnull(tryparse(AminoAcid, ""))
             @test isnull(tryparse(AminoAcid, "AL"))
             @test isnull(tryparse(AminoAcid, "LA"))
             @test isnull(tryparse(AminoAcid, "ALAA"))
+            @test isnull(tryparse(AminoAcid, '\0'))
+            @test isnull(tryparse(AminoAcid, '@'))
+            @test isnull(tryparse(AminoAcid, '亜'))
         end
     end
 end


### PR DESCRIPTION
This is ~5x faster than the current Dict lookup and does no allocation.

```
julia> @benchmark parse_aa(strs)  # master
WARNING: Method definition parse(Type{BioSymbols.AminoAcid}, AbstractString) in module BioSymbols at /Users/kenta/.julia/v0.6/BioSymbols/src/aminoacid.jl:220 overwritten at /Users/kenta/.julia/v0.6/BioSymbols/src/aminoacid.jl:3.
BenchmarkTools.Trial:
  memory estimate:  3.44 KiB
  allocs estimate:  80
  --------------
  minimum time:     4.328 μs (0.00% GC)
  median time:      4.522 μs (0.00% GC)
  mean time:        5.300 μs (7.23% GC)
  maximum time:     424.362 μs (97.17% GC)
  --------------
  samples:          10000
  evals/sample:     7

julia> @benchmark parse_aa(strs)  # rewrite-aa-parser
WARNING: Method definition parse(Type{BioSymbols.AminoAcid}, AbstractString) in module BioSymbols at /Users/kenta/.julia/v0.6/BioSymbols/src/aminoacid.jl:3 overwritten at /Users/kenta/.julia/v0.6/BioSymbols/src/aminoacid.jl:58.
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     865.945 ns (0.00% GC)
  median time:      896.618 ns (0.00% GC)
  mean time:        970.133 ns (0.00% GC)
  maximum time:     3.437 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     55

```

```
using BioSymbols
using BenchmarkTools

function parse_aa(strs)
    for s in strs
        parse(AminoAcid, s)
    end
end

const strs = [
    "ALA", "ASP", "GLN", "ILE", "VAL",
    "ala", "asp", "gln", "ile", "pro",
    "A",   "D",   "Q",   "I",   "V",
]
```

This is written using new interfaces of Automa.jl, so we need to wait for https://github.com/JuliaLang/METADATA.jl/pull/10278.