### PR TITLE
Remove integer conversion and arithmetic

### DIFF
--- a/docs/src/sequences.md
+++ b/docs/src/sequences.md
@@ -60,5 +60,4 @@ which means 50% of a `Vector{DNA}`'s space is not used at all.
 For the purpose of representing sequences as efficient as possible BioJulia has
 developed [BioSequences](https://github.com/BioJulia/BioSequences.jl)
 package. The `BioSequence` type is able to represent a DNA/RNA sequence in 2 or
-4 bits per symbol. It also offers many efficient algorithms and I/O tools for
-common file formats such as FASTA.
+4 bits per symbol. It also offers many efficient algorithms.

--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -96,7 +96,8 @@ export
     iscompatible,
     compatbits,
     alphabet,
-    encoded_data
+    encoded_data,
+    encode
 
 import Automa
 import Automa.RegExp: @re_str
@@ -118,6 +119,9 @@ expected to have the following methods defined:
 abstract type BioSymbol end
 
 encoded_data(x::BioSymbol) = reinterpret(encoded_data_eltype(typeof(x)), x)
+function encode(::Type{T}, x) where T <: BioSymbol
+    return reinterpret(T, convert(encoded_data_eltype(T), x))
+end
 Base.length(::BioSymbol) = 1
 Base.iterate(sym::BioSymbol) = (sym, nothing)
 Base.iterate(sym::BioSymbol, state) = nothing
@@ -139,15 +143,6 @@ isgap(symbol::BioSymbol) = symbol == gap(typeof(symbol))
 # These methods are necessary when deriving some algorithims
 # like iteration, sort, comparison, and so on.
 Base.isless(x::S, y::S) where S <: BioSymbol = isless(encoded_data(x), encoded_data(y))
-
-function Base.:~(x::BioSymbol)
-    return reinterpret(typeof(x), ~encoded_data(x) & bytemask(x))
-end
-
-function Base.:&(x::S, y::S) where S <: BioSymbol
-    return reinterpret(S, encoded_data(x) & encoded_data(y))
-end
-
 
 @inline function Base.count_ones(symbol::BioSymbol)
     return count_ones(encoded_data(symbol))
@@ -188,7 +183,7 @@ function Base.print(io::IO, symbol::BioSymbol)
 end
 
 Base.write(io::IO, symbol::BioSymbol) = write(io, encoded_data(symbol))
-Base.read(io::IO, ::Type{T}) where T<:BioSymbol = reinterpret(T, read(io, encoded_data_eltype(T)))
+Base.read(io::IO, ::Type{T}) where T<:BioSymbol = encode(T, read(io, encoded_data_eltype(T)))
 
 """
     iscompatible(x::S, y::S) where S <: BioSymbol

--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -95,7 +95,8 @@ export
     complement,
     iscompatible,
     compatbits,
-    alphabet
+    alphabet,
+    encoded_data
 
 import Automa
 import Automa.RegExp: @re_str
@@ -116,6 +117,7 @@ expected to have the following methods defined:
 """
 abstract type BioSymbol end
 
+encoded_data(x::BioSymbol) = reinterpret(encoded_data_eltype(typeof(x)), x)
 Base.length(::BioSymbol) = 1
 Base.iterate(sym::BioSymbol) = (sym, nothing)
 Base.iterate(sym::BioSymbol, state) = nothing
@@ -136,34 +138,24 @@ isgap(symbol::BioSymbol) = symbol == gap(typeof(symbol))
 
 # These methods are necessary when deriving some algorithims
 # like iteration, sort, comparison, and so on.
-
-Base.:-(x::S, y::S) where S <: BioSymbol = convert(Int, x) - convert(Int, y)
-
-Base.:+(x::Integer, y::BioSymbol) = y + x
-
-Base.isless(x::S, y::S) where S <: BioSymbol = isless(convert(Integer, x), convert(Integer, y))
+Base.isless(x::S, y::S) where S <: BioSymbol = isless(encoded_data(x), encoded_data(y))
 
 function Base.:~(x::BioSymbol)
-    return reinterpret(typeof(x), ~reinterpret(UInt8, x) & bytemask(x))
+    return reinterpret(typeof(x), ~encoded_data(x) & bytemask(x))
 end
 
 function Base.:&(x::S, y::S) where S <: BioSymbol
-    return reinterpret(S, convert(Integer, x) & convert(Integer, y))
+    return reinterpret(S, encoded_data(x) & encoded_data(y))
 end
 
 
 @inline function Base.count_ones(symbol::BioSymbol)
-    return count_ones(convert(Integer, symbol))
+    return count_ones(encoded_data(symbol))
 end
 
 @inline function Base.trailing_zeros(symbol::BioSymbol)
-    return trailing_zeros(convert(Integer, symbol))
+    return trailing_zeros(encoded_data(symbol))
 end
-
-
-
-
-
 
 # Printing BioSymbols
 # -------------------
@@ -195,9 +187,8 @@ function Base.print(io::IO, symbol::BioSymbol)
     return nothing
 end
 
-Base.write(io::IO, symbol::BioSymbol) = write(io, convert(Integer, symbol))
-Base.read(io::IO, ::Type{T}) where T<:BioSymbol = reinterpret(T, read(io, UInt8))    
-
+Base.write(io::IO, symbol::BioSymbol) = write(io, encoded_data(symbol))
+Base.read(io::IO, ::Type{T}) where T<:BioSymbol = reinterpret(T, read(io, encoded_data_eltype(T)))
 
 """
     iscompatible(x::S, y::S) where S <: BioSymbol

--- a/src/aminoacid.jl
+++ b/src/aminoacid.jl
@@ -38,7 +38,7 @@ Char(aa::AminoAcid) = convert(Char, aa)
 # ------------------------------
 
 "Invalid Amino Acid"
-const AA_INVALID = reinterpret(AminoAcid, 0x1c)  # Used during conversion from strings
+const AA_INVALID = encode(AminoAcid, 0x1c)  # Used during conversion from strings
 
 # lookup table for characters
 const char_to_aa = [AA_INVALID for _ in 0x00:0x7f]
@@ -78,7 +78,7 @@ const (aa_to_char, compatbits_aa) = let
         ('X', "Unspecified or Unknown Amino Acid", 0x19)]  # ambiguous
         var = Symbol("AA_", aa)
         @eval begin
-            @doc $doc const $var = reinterpret(AminoAcid, $code)
+            @doc $doc const $var = encode(AminoAcid, $code)
             char_to_aa[$(Int(aa)+1)] = char_to_aa[$(Int(lowercase(aa))+1)] = $var
             $(aatochar)[$(code)+1] = $aa
         end
@@ -97,13 +97,13 @@ const (aa_to_char, compatbits_aa) = let
 
     @eval begin
         "Terminal"
-        const AA_Term = reinterpret(AminoAcid, 0x1a)
+        const AA_Term = encode(AminoAcid, 0x1a)
         char_to_aa[Int('*')+1] = AA_Term
         $(aatochar)[0x1a+1] = '*'
         $(compatbitsaa)[0x1a+1] = 1 << 0x1a
 
         "Amino Acid Gap"
-        const AA_Gap = reinterpret(AminoAcid, 0x1b)
+        const AA_Gap = encode(AminoAcid, 0x1b)
         char_to_aa[Int('-') + 1] = AA_Gap
         $(aatochar)[0x1b+1] = '-'
         $(compatbitsaa)[0x1b+1] = 0
@@ -111,7 +111,7 @@ const (aa_to_char, compatbits_aa) = let
     (Tuple(aatochar), Tuple(compatbitsaa))
 end
 
-@eval alphabet(::Type{AminoAcid}) = $(tuple([reinterpret(AminoAcid, x) for x in 0x00:0x1b]...))
+@eval alphabet(::Type{AminoAcid}) = $(tuple([encode(AminoAcid, x) for x in 0x00:0x1b]...))
 
 """
     alphabet(AminoAcid)
@@ -272,4 +272,4 @@ julia> compatbits(AA_J)
 
 ```
 """
-compatbits(aa::AminoAcid) = @inbounds compatbits_aa[reinterpret(UInt8, aa) + 1]
+compatbits(aa::AminoAcid) = @inbounds compatbits_aa[encoded_data(aa) + 1]

--- a/src/nucleicacid.jl
+++ b/src/nucleicacid.jl
@@ -66,7 +66,7 @@ function Base.convert(::Type{DNA}, c::Char)
     if !isvalid(DNA, dna)
         throw(InexactError(:convert, DNA, c))
     end
-    return reinterpret(DNA, dna)
+    return encode(DNA, dna)
 end
 DNA(c::Char) = convert(DNA, c)
 
@@ -78,7 +78,7 @@ function Base.convert(::Type{RNA}, c::Char)
     if !isvalid(RNA, rna)
         throw(InexactError(:convert, RNA, c))
     end
-    return reinterpret(RNA, rna)
+    return encode(RNA, rna)
 end
 RNA(c::Char) = convert(RNA, c)
 
@@ -163,7 +163,7 @@ const dna_to_char = let
         ('N', "DNA Adenine, Cytosine, Guanine or Thymine", 0b1111)]
         var = Symbol("DNA_", char != '-' ? char : "Gap")
         @eval begin
-            @doc $(doc) const $(var) = reinterpret(DNA, $(bits))
+            @doc $(doc) const $(var) = encode(DNA, $(bits))
             char_to_dna[$(convert(Int, char) + 1)] = char_to_dna[$(convert(Int, lowercase(char)) + 1)] = $(bits)
             $(chararray)[$(convert(Int, bits) + 1)] = $(char)
         end
@@ -172,7 +172,7 @@ const dna_to_char = let
 end
 
 @eval function alphabet(::Type{DNA})
-    return $(tuple([reinterpret(DNA, x) for x in 0b0000:0b1111]...))
+    return $(tuple([encode(DNA, x) for x in 0b0000:0b1111]...))
 end
 
 """
@@ -300,7 +300,7 @@ const rna_to_char = let
 end
 
 @eval function alphabet(::Type{RNA})
-    return $(tuple([reinterpret(RNA, x) for x in 0b0000:0b1111]...))
+    return $(tuple([encode(RNA, x) for x in 0b0000:0b1111]...))
 end
 
 """
@@ -353,14 +353,6 @@ julia> ACGUN
 ```
 """
 const ACGUN = (RNA_A, RNA_C, RNA_G, RNA_U, RNA_N)
-
-function Base.:~(x::N) where N <: NucleicAcid
-    return reinterpret(N, ~encoded_data(x) & 0b1111)
-end
-
-function Base.:|(x::N, y::N) where N <: NucleicAcid
-    return reinterpret(N, encoded_data(x) | encoded_data(y))
-end
 
 """
     gap(DNA)
@@ -448,7 +440,7 @@ RNA_A
 """
 function complement(nt::NucleicAcid)
     bits = compatbits(nt)
-    return reinterpret(
+    return encode(
         typeof(nt),
         (bits & 0x01) << 3 | (bits & 0x08) >> 3 |
         (bits & 0x02) << 1 | (bits & 0x04) >> 1)

--- a/src/nucleicacid.jl
+++ b/src/nucleicacid.jl
@@ -454,6 +454,17 @@ function Base.isvalid(nt::NucleicAcid)
     return encoded_data(nt) ≤ 0b1111
 end
 
+function Base.:~(x::N) where N <: NucleicAcid
+    return encode(N, encoded_data(x) ⊻ 0b1111)
+end
+
+function Base.:|(x::N, y::N) where N <: NucleicAcid
+    return encode(N, encoded_data(x) | encoded_data(y))
+end
+
+function Base.:&(x::N, y::N) where N <: NucleicAcid
+    return encode(N, encoded_data(x) & encoded_data(y))
+end
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,42 +29,42 @@ end
 @testset "NucleicAcids" begin
     @testset "Conversions" begin
         @testset "UInt8" begin
-            @testset "DNA conversions from UInt8" begin
-                @test reinterpret(DNA, 0b0000) === DNA_Gap
-                @test reinterpret(DNA, 0b0001) === DNA_A
-                @test reinterpret(DNA, 0b0010) === DNA_C
-                @test reinterpret(DNA, 0b0011) === DNA_M
-                @test reinterpret(DNA, 0b0100) === DNA_G
-                @test reinterpret(DNA, 0b0101) === DNA_R
-                @test reinterpret(DNA, 0b0110) === DNA_S
-                @test reinterpret(DNA, 0b0111) === DNA_V
-                @test reinterpret(DNA, 0b1000) === DNA_T
-                @test reinterpret(DNA, 0b1001) === DNA_W
-                @test reinterpret(DNA, 0b1010) === DNA_Y
-                @test reinterpret(DNA, 0b1011) === DNA_H
-                @test reinterpret(DNA, 0b1100) === DNA_K
-                @test reinterpret(DNA, 0b1101) === DNA_D
-                @test reinterpret(DNA, 0b1110) === DNA_B
-                @test reinterpret(DNA, 0b1111) === DNA_N
+            @testset "DNA encoding from UInt8" begin
+                @test encode(DNA, 0b0000) === DNA_Gap
+                @test encode(DNA, 0b0001) === DNA_A
+                @test encode(DNA, 0b0010) === DNA_C
+                @test encode(DNA, 0b0011) === DNA_M
+                @test encode(DNA, 0b0100) === DNA_G
+                @test encode(DNA, 0b0101) === DNA_R
+                @test encode(DNA, 0b0110) === DNA_S
+                @test encode(DNA, 0b0111) === DNA_V
+                @test encode(DNA, 0b1000) === DNA_T
+                @test encode(DNA, 0b1001) === DNA_W
+                @test encode(DNA, 0b1010) === DNA_Y
+                @test encode(DNA, 0b1011) === DNA_H
+                @test encode(DNA, 0b1100) === DNA_K
+                @test encode(DNA, 0b1101) === DNA_D
+                @test encode(DNA, 0b1110) === DNA_B
+                @test encode(DNA, 0b1111) === DNA_N
             end
 
-            @testset "RNA conversions from UInt8" begin
-                @test reinterpret(RNA, 0b0000) === RNA_Gap
-                @test reinterpret(RNA, 0b0001) === RNA_A
-                @test reinterpret(RNA, 0b0010) === RNA_C
-                @test reinterpret(RNA, 0b0011) === RNA_M
-                @test reinterpret(RNA, 0b0100) === RNA_G
-                @test reinterpret(RNA, 0b0101) === RNA_R
-                @test reinterpret(RNA, 0b0110) === RNA_S
-                @test reinterpret(RNA, 0b0111) === RNA_V
-                @test reinterpret(RNA, 0b1000) === RNA_U
-                @test reinterpret(RNA, 0b1001) === RNA_W
-                @test reinterpret(RNA, 0b1010) === RNA_Y
-                @test reinterpret(RNA, 0b1011) === RNA_H
-                @test reinterpret(RNA, 0b1100) === RNA_K
-                @test reinterpret(RNA, 0b1101) === RNA_D
-                @test reinterpret(RNA, 0b1110) === RNA_B
-                @test reinterpret(RNA, 0b1111) === RNA_N
+            @testset "RNA encoding from UInt8" begin
+                @test encode(RNA, 0b0000) === RNA_Gap
+                @test encode(RNA, 0b0001) === RNA_A
+                @test encode(RNA, 0b0010) === RNA_C
+                @test encode(RNA, 0b0011) === RNA_M
+                @test encode(RNA, 0b0100) === RNA_G
+                @test encode(RNA, 0b0101) === RNA_R
+                @test encode(RNA, 0b0110) === RNA_S
+                @test encode(RNA, 0b0111) === RNA_V
+                @test encode(RNA, 0b1000) === RNA_U
+                @test encode(RNA, 0b1001) === RNA_W
+                @test encode(RNA, 0b1010) === RNA_Y
+                @test encode(RNA, 0b1011) === RNA_H
+                @test encode(RNA, 0b1100) === RNA_K
+                @test encode(RNA, 0b1101) === RNA_D
+                @test encode(RNA, 0b1110) === RNA_B
+                @test encode(RNA, 0b1111) === RNA_N
             end
 
             @testset "DNA conversions to UInt8" begin
@@ -261,10 +261,6 @@ end
 
     @testset "Arithmetic and Order" begin
         @testset "DNA" begin
-            @test ~DNA_Gap === DNA_N
-            @test ~DNA_N   === DNA_Gap
-            @test DNA_A | DNA_C === DNA_M
-            @test DNA_A & DNA_C === DNA_Gap
             @test DNA_Gap < DNA_A < DNA_C < DNA_G < DNA_T < DNA_N
             @test !(DNA_A > DNA_G)
             @test trailing_zeros(DNA_A) === 0
@@ -279,10 +275,6 @@ end
                 DNA_D, DNA_B, DNA_N, DNA_Gap])
         end
         @testset "RNA" begin
-            @test ~RNA_Gap === RNA_N
-            @test ~RNA_N   === RNA_Gap
-            @test RNA_A | RNA_C === RNA_M
-            @test RNA_A & RNA_C === RNA_Gap
             @test RNA_Gap < RNA_A < RNA_C < RNA_G < RNA_U < RNA_N
             @test !(RNA_A > RNA_G)
             @test trailing_zeros(RNA_A) === 0
@@ -306,7 +298,7 @@ end
                 print(buf, nt)
             end
             @test String(take!(buf)) == "ACGTN-"
-            @test_throws ArgumentError print(reinterpret(DNA, 0xf0))
+            @test_throws ArgumentError print(encode(DNA, 0xf0))
         end
 
         @testset "show" begin
@@ -319,7 +311,7 @@ end
                 write(buf, ' ')
             end
             @test String(take!(buf)) == "DNA_A DNA_C DNA_G DNA_T DNA_N DNA_Gap "
-            @test sprint(show, reinterpret(DNA, 0xf0)) == "Invalid DNA"
+            @test sprint(show, encode(DNA, 0xf0)) == "Invalid DNA"
         end
     end
 
@@ -331,7 +323,7 @@ end
                 print(buf, nt)
             end
             @test String(take!(buf)) == "ACGUN-"
-            @test_throws ArgumentError print(reinterpret(RNA, 0xf0))
+            @test_throws ArgumentError print(encode(RNA, 0xf0))
         end
 
         @testset "show" begin
@@ -344,7 +336,7 @@ end
                 write(buf, ' ')
             end
             @test String(take!(buf)) == "RNA_A RNA_C RNA_G RNA_U RNA_N RNA_Gap "
-            @test sprint(show, reinterpret(RNA, 0xf0)) == "Invalid RNA"
+            @test sprint(show, encode(RNA, 0xf0)) == "Invalid RNA"
         end
 
         @testset "read and write" begin
@@ -397,11 +389,11 @@ end
             (0x0f, AA_S), (0x10, AA_T), (0x11, AA_W), (0x12, AA_Y), (0x13, AA_V),
             (0x14, AA_O), (0x15, AA_U), (0x16, AA_B), (0x17, AA_J), (0x18, AA_Z),
             (0x19, AA_X), (0x1a, AA_Term), (0x1b, AA_Gap)]
-            @test reinterpret(AminoAcid, int) === aa
+            @test encode(AminoAcid, int) === aa
         end
 
-        @test reinterpret(AminoAcid, UInt8(0)) === AA_A
-        @test reinterpret(AminoAcid, UInt8(10)) === AA_L
+        @test encode(AminoAcid, UInt8(0)) === AA_A
+        @test encode(AminoAcid, UInt8(10)) === AA_L
 
         for (c, aa) in [
                 ('A', AA_A), ('R', AA_R), ('N', AA_N), ('D', AA_D), ('C', AA_C),
@@ -422,8 +414,8 @@ end
         for aa in alphabet(AminoAcid)
             @test isvalid(aa)
         end
-        @test !isvalid(reinterpret(AminoAcid, 0x1c))
-        @test !isvalid(reinterpret(AminoAcid, 0xff))
+        @test !isvalid(encode(AminoAcid, 0x1c))
+        @test !isvalid(encode(AminoAcid, 0xff))
         @test  isvalid(AminoAcid, 0x1b)
         @test !isvalid(AminoAcid, 0x1c)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,117 +30,79 @@ end
     @testset "Conversions" begin
         @testset "UInt8" begin
             @testset "DNA conversions from UInt8" begin
-                @test convert(DNA, 0b0000) === DNA_Gap
-                @test convert(DNA, 0b0001) === DNA_A
-                @test convert(DNA, 0b0010) === DNA_C
-                @test convert(DNA, 0b0011) === DNA_M
-                @test convert(DNA, 0b0100) === DNA_G
-                @test convert(DNA, 0b0101) === DNA_R
-                @test convert(DNA, 0b0110) === DNA_S
-                @test convert(DNA, 0b0111) === DNA_V
-                @test convert(DNA, 0b1000) === DNA_T
-                @test convert(DNA, 0b1001) === DNA_W
-                @test convert(DNA, 0b1010) === DNA_Y
-                @test convert(DNA, 0b1011) === DNA_H
-                @test convert(DNA, 0b1100) === DNA_K
-                @test convert(DNA, 0b1101) === DNA_D
-                @test convert(DNA, 0b1110) === DNA_B
-                @test convert(DNA, 0b1111) === DNA_N
+                @test reinterpret(DNA, 0b0000) === DNA_Gap
+                @test reinterpret(DNA, 0b0001) === DNA_A
+                @test reinterpret(DNA, 0b0010) === DNA_C
+                @test reinterpret(DNA, 0b0011) === DNA_M
+                @test reinterpret(DNA, 0b0100) === DNA_G
+                @test reinterpret(DNA, 0b0101) === DNA_R
+                @test reinterpret(DNA, 0b0110) === DNA_S
+                @test reinterpret(DNA, 0b0111) === DNA_V
+                @test reinterpret(DNA, 0b1000) === DNA_T
+                @test reinterpret(DNA, 0b1001) === DNA_W
+                @test reinterpret(DNA, 0b1010) === DNA_Y
+                @test reinterpret(DNA, 0b1011) === DNA_H
+                @test reinterpret(DNA, 0b1100) === DNA_K
+                @test reinterpret(DNA, 0b1101) === DNA_D
+                @test reinterpret(DNA, 0b1110) === DNA_B
+                @test reinterpret(DNA, 0b1111) === DNA_N
             end
 
             @testset "RNA conversions from UInt8" begin
-                @test convert(RNA, 0b0000) === RNA_Gap
-                @test convert(RNA, 0b0001) === RNA_A
-                @test convert(RNA, 0b0010) === RNA_C
-                @test convert(RNA, 0b0011) === RNA_M
-                @test convert(RNA, 0b0100) === RNA_G
-                @test convert(RNA, 0b0101) === RNA_R
-                @test convert(RNA, 0b0110) === RNA_S
-                @test convert(RNA, 0b0111) === RNA_V
-                @test convert(RNA, 0b1000) === RNA_U
-                @test convert(RNA, 0b1001) === RNA_W
-                @test convert(RNA, 0b1010) === RNA_Y
-                @test convert(RNA, 0b1011) === RNA_H
-                @test convert(RNA, 0b1100) === RNA_K
-                @test convert(RNA, 0b1101) === RNA_D
-                @test convert(RNA, 0b1110) === RNA_B
-                @test convert(RNA, 0b1111) === RNA_N
+                @test reinterpret(RNA, 0b0000) === RNA_Gap
+                @test reinterpret(RNA, 0b0001) === RNA_A
+                @test reinterpret(RNA, 0b0010) === RNA_C
+                @test reinterpret(RNA, 0b0011) === RNA_M
+                @test reinterpret(RNA, 0b0100) === RNA_G
+                @test reinterpret(RNA, 0b0101) === RNA_R
+                @test reinterpret(RNA, 0b0110) === RNA_S
+                @test reinterpret(RNA, 0b0111) === RNA_V
+                @test reinterpret(RNA, 0b1000) === RNA_U
+                @test reinterpret(RNA, 0b1001) === RNA_W
+                @test reinterpret(RNA, 0b1010) === RNA_Y
+                @test reinterpret(RNA, 0b1011) === RNA_H
+                @test reinterpret(RNA, 0b1100) === RNA_K
+                @test reinterpret(RNA, 0b1101) === RNA_D
+                @test reinterpret(RNA, 0b1110) === RNA_B
+                @test reinterpret(RNA, 0b1111) === RNA_N
             end
 
             @testset "DNA conversions to UInt8" begin
-                @test convert(UInt8, DNA_Gap) === 0b0000
-                @test convert(UInt8, DNA_A)   === 0b0001
-                @test convert(UInt8, DNA_C)   === 0b0010
-                @test convert(UInt8, DNA_M)   === 0b0011
-                @test convert(UInt8, DNA_G)   === 0b0100
-                @test convert(UInt8, DNA_R)   === 0b0101
-                @test convert(UInt8, DNA_S)   === 0b0110
-                @test convert(UInt8, DNA_V)   === 0b0111
-                @test convert(UInt8, DNA_T)   === 0b1000
-                @test convert(UInt8, DNA_W)   === 0b1001
-                @test convert(UInt8, DNA_Y)   === 0b1010
-                @test convert(UInt8, DNA_H)   === 0b1011
-                @test convert(UInt8, DNA_K)   === 0b1100
-                @test convert(UInt8, DNA_D)   === 0b1101
-                @test convert(UInt8, DNA_B)   === 0b1110
-                @test convert(UInt8, DNA_N)   === 0b1111
+                @test encoded_data(DNA_Gap) === 0b0000
+                @test encoded_data(DNA_A)   === 0b0001
+                @test encoded_data(DNA_C)   === 0b0010
+                @test encoded_data(DNA_M)   === 0b0011
+                @test encoded_data(DNA_G)   === 0b0100
+                @test encoded_data(DNA_R)   === 0b0101
+                @test encoded_data(DNA_S)   === 0b0110
+                @test encoded_data(DNA_V)   === 0b0111
+                @test encoded_data(DNA_T)   === 0b1000
+                @test encoded_data(DNA_W)   === 0b1001
+                @test encoded_data(DNA_Y)   === 0b1010
+                @test encoded_data(DNA_H)   === 0b1011
+                @test encoded_data(DNA_K)   === 0b1100
+                @test encoded_data(DNA_D)   === 0b1101
+                @test encoded_data(DNA_B)   === 0b1110
+                @test encoded_data(DNA_N)   === 0b1111
             end
 
             @testset "RNA conversions to UInt8" begin
-                @test convert(UInt8, RNA_Gap) === 0b0000
-                @test convert(UInt8, RNA_A)   === 0b0001
-                @test convert(UInt8, RNA_C)   === 0b0010
-                @test convert(UInt8, RNA_M)   === 0b0011
-                @test convert(UInt8, RNA_G)   === 0b0100
-                @test convert(UInt8, RNA_R)   === 0b0101
-                @test convert(UInt8, RNA_S)   === 0b0110
-                @test convert(UInt8, RNA_V)   === 0b0111
-                @test convert(UInt8, RNA_U)   === 0b1000
-                @test convert(UInt8, RNA_W)   === 0b1001
-                @test convert(UInt8, RNA_Y)   === 0b1010
-                @test convert(UInt8, RNA_H)   === 0b1011
-                @test convert(UInt8, RNA_K)   === 0b1100
-                @test convert(UInt8, RNA_D)   === 0b1101
-                @test convert(UInt8, RNA_B)   === 0b1110
-                @test convert(UInt8, RNA_N)   === 0b1111
-            end
-        end
-
-        @testset "UInt64" begin
-            @testset "DNA conversions from UInt64" begin
-                @test convert(DNA, UInt64(0b0000)) === DNA_Gap
-                @test convert(DNA, UInt64(0b0001)) === DNA_A
-                @test convert(DNA, UInt64(0b0010)) === DNA_C
-                @test convert(DNA, UInt64(0b0100)) === DNA_G
-                @test convert(DNA, UInt64(0b1000)) === DNA_T
-                @test convert(DNA, UInt64(0b1111)) === DNA_N
-            end
-
-            @testset "RNA conversions from UInt64" begin
-                @test convert(RNA, UInt64(0b0000)) === RNA_Gap
-                @test convert(RNA, UInt64(0b0001)) === RNA_A
-                @test convert(RNA, UInt64(0b0010)) === RNA_C
-                @test convert(RNA, UInt64(0b0100)) === RNA_G
-                @test convert(RNA, UInt64(0b1000)) === RNA_U
-                @test convert(RNA, UInt64(0b1111)) === RNA_N
-            end
-
-            @testset "DNA conversions to UInt64" begin
-                @test convert(UInt64, DNA_Gap) === UInt64(0b0000)
-                @test convert(UInt64, DNA_A)   === UInt64(0b0001)
-                @test convert(UInt64, DNA_C)   === UInt64(0b0010)
-                @test convert(UInt64, DNA_G)   === UInt64(0b0100)
-                @test convert(UInt64, DNA_T)   === UInt64(0b1000)
-                @test convert(UInt64, DNA_N)   === UInt64(0b1111)
-            end
-
-            @testset "RNA conversions to UInt64" begin
-                @test convert(UInt64, RNA_Gap) === UInt64(0b0000)
-                @test convert(UInt64, RNA_A)   === UInt64(0b0001)
-                @test convert(UInt64, RNA_C)   === UInt64(0b0010)
-                @test convert(UInt64, RNA_G)   === UInt64(0b0100)
-                @test convert(UInt64, RNA_U)   === UInt64(0b1000)
-                @test convert(UInt64, RNA_N)   === UInt64(0b1111)
+                @test encoded_data(RNA_Gap) === 0b0000
+                @test encoded_data(RNA_A)   === 0b0001
+                @test encoded_data(RNA_C)   === 0b0010
+                @test encoded_data(RNA_M)   === 0b0011
+                @test encoded_data(RNA_G)   === 0b0100
+                @test encoded_data(RNA_R)   === 0b0101
+                @test encoded_data(RNA_S)   === 0b0110
+                @test encoded_data(RNA_V)   === 0b0111
+                @test encoded_data(RNA_U)   === 0b1000
+                @test encoded_data(RNA_W)   === 0b1001
+                @test encoded_data(RNA_Y)   === 0b1010
+                @test encoded_data(RNA_H)   === 0b1011
+                @test encoded_data(RNA_K)   === 0b1100
+                @test encoded_data(RNA_D)   === 0b1101
+                @test encoded_data(RNA_B)   === 0b1110
+                @test encoded_data(RNA_N)   === 0b1111
             end
         end
 
@@ -182,37 +144,13 @@ end
             end
         end
 
-        @testset "Other numeric types" begin
-            @test convert(Int, DNA_A) === 1
-            @test convert(Int, DNA_C) === 2
-            @test convert(Int, DNA_G) === 4
-            @test convert(Int, DNA_T) === 8
-            @test convert(Int, DNA_N) === 15
-            @test convert(DNA,  1) === DNA_A
-            @test convert(DNA,  2) === DNA_C
-            @test convert(DNA,  4) === DNA_G
-            @test convert(DNA,  8) === DNA_T
-            @test convert(DNA, 15) === DNA_N
-
-            @test convert(Int, RNA_A) === 1
-            @test convert(Int, RNA_C) === 2
-            @test convert(Int, RNA_G) === 4
-            @test convert(Int, RNA_U) === 8
-            @test convert(Int, RNA_N) === 15
-            @test convert(RNA,  1) === RNA_A
-            @test convert(RNA,  2) === RNA_C
-            @test convert(RNA,  4) === RNA_G
-            @test convert(RNA,  8) === RNA_U
-            @test convert(RNA, 15) === RNA_N
-        end
-        
         @testset "Nucleic acid types" begin
             fromto = [(DNA_Gap, RNA_Gap), (DNA_A, RNA_A), (DNA_C, RNA_C),
                       (DNA_M, RNA_M), (DNA_G, RNA_G), (DNA_R, RNA_R),
                       (DNA_S, RNA_S), (DNA_V, RNA_V), (DNA_T, RNA_U),
                       (DNA_W, RNA_W), (DNA_Y, RNA_Y), (DNA_H, RNA_H),
                       (DNA_K, RNA_K), (DNA_D, RNA_D), (DNA_B, RNA_B), (DNA_N, RNA_N)]
-            
+
             for (from, to) in fromto
                 @test convert(RNA, from) === RNA(from) === to
                 @test convert(DNA, to) === DNA(to) === from
@@ -295,7 +233,7 @@ end
             @test isgap(nt) == (nt === RNA_Gap)
         end
     end
-    
+
     @testset "isterm" begin
         for nt in alphabet(DNA)
             @test BioSymbols.isterm(nt) === false
@@ -327,10 +265,6 @@ end
             @test ~DNA_N   === DNA_Gap
             @test DNA_A | DNA_C === DNA_M
             @test DNA_A & DNA_C === DNA_Gap
-            @test DNA_Gap - DNA_A   === -1
-            @test DNA_A   - DNA_Gap === +1
-            @test DNA_Gap + 1 === DNA_Gap + 17 === DNA_A
-            @test DNA_Gap - 1 === DNA_Gap - 17 === DNA_N
             @test DNA_Gap < DNA_A < DNA_C < DNA_G < DNA_T < DNA_N
             @test !(DNA_A > DNA_G)
             @test trailing_zeros(DNA_A) === 0
@@ -349,10 +283,6 @@ end
             @test ~RNA_N   === RNA_Gap
             @test RNA_A | RNA_C === RNA_M
             @test RNA_A & RNA_C === RNA_Gap
-            @test RNA_Gap - RNA_A   === -1
-            @test RNA_A   - RNA_Gap === +1
-            @test RNA_Gap + 1 === RNA_Gap + 17 === RNA_A
-            @test RNA_Gap - 1 === RNA_Gap - 17 === RNA_N
             @test RNA_Gap < RNA_A < RNA_C < RNA_G < RNA_U < RNA_N
             @test !(RNA_A > RNA_G)
             @test trailing_zeros(RNA_A) === 0
@@ -416,7 +346,7 @@ end
             @test String(take!(buf)) == "RNA_A RNA_C RNA_G RNA_U RNA_N RNA_Gap "
             @test sprint(show, reinterpret(RNA, 0xf0)) == "Invalid RNA"
         end
-        
+
         @testset "read and write" begin
             @test round_trip(AA_X)
             @test round_trip(AA_Y)
@@ -459,7 +389,7 @@ end
 @testset "Aminoacids" begin
     @testset "conversion" begin
         @test BioSymbols.bytemask(AA_A) === 0b11111
-        
+
         for (int, aa) in [
             (0x00, AA_A), (0x01, AA_R), (0x02, AA_N), (0x03, AA_D), (0x04, AA_C),
             (0x05, AA_Q), (0x06, AA_E), (0x07, AA_G), (0x08, AA_H), (0x09, AA_I),
@@ -467,11 +397,11 @@ end
             (0x0f, AA_S), (0x10, AA_T), (0x11, AA_W), (0x12, AA_Y), (0x13, AA_V),
             (0x14, AA_O), (0x15, AA_U), (0x16, AA_B), (0x17, AA_J), (0x18, AA_Z),
             (0x19, AA_X), (0x1a, AA_Term), (0x1b, AA_Gap)]
-            @test convert(AminoAcid, int) === AminoAcid(int) === aa
+            @test reinterpret(AminoAcid, int) === aa
         end
 
-        @test convert(AminoAcid, 0) === AA_A
-        @test convert(AminoAcid, 10) === AA_L
+        @test reinterpret(AminoAcid, UInt8(0)) === AA_A
+        @test reinterpret(AminoAcid, UInt8(10)) === AA_L
 
         for (c, aa) in [
                 ('A', AA_A), ('R', AA_R), ('N', AA_N), ('D', AA_D), ('C', AA_C),
@@ -499,15 +429,6 @@ end
     end
 
     @testset "Arithmetic and Order" begin
-        @test AA_A + 1 == 1 + AA_A == AA_R
-        @test AA_R + 1 == 1 + AA_R == AA_N
-        @test AA_A + 2 == 2 + AA_A == AA_N
-        @test AA_A + 28 == 28 + AA_A == AA_A
-        @test AA_R - 1 == AA_A
-        @test AA_N - 2 == AA_A
-        @test AA_A - 28 == AA_A
-        @test AA_D - AA_A ==  3
-        @test AA_A - AA_D == -3
         @test (AA_A < AA_R < AA_N < AA_V < AA_O < AA_U <
                AA_B < AA_J < AA_Z < AA_X < AA_Term < AA_Gap)
         @test !(AA_J < AA_B)
@@ -517,17 +438,6 @@ end
         @test AA_A in alphabet(AminoAcid)
         @test AA_I in alphabet(AminoAcid)
         @test AA_U in alphabet(AminoAcid)
-    end
-
-    @testset "Range" begin
-        @test !(AA_C in AA_Q:AA_H)
-        @test   AA_Q in AA_Q:AA_H
-        @test   AA_E in AA_Q:AA_H
-        @test   AA_G in AA_Q:AA_H
-        @test   AA_H in AA_Q:AA_H
-        @test !(AA_I in AA_Q:AA_H)
-
-        @test collect(AA_W:AA_V) == [AA_W, AA_Y, AA_V]
     end
 
     @testset "iscompatible" begin
@@ -584,7 +494,7 @@ end
             @test String(take!(buf)) == "AA_A AA_D AA_B AA_X AA_Term AA_Gap "
             @test sprint(show, BioSymbols.AA_INVALID) == "Invalid Amino Acid"
         end
-        
+
         @testset "read and write" begin
             @test round_trip(DNA_G)
             @test round_trip(RNA_U)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,8 +259,14 @@ end
         @test complement(RNA_N) === RNA_N
     end
 
-    @testset "Arithmetic and Order" begin
+    @testset "Logic operations and Order" begin
         @testset "DNA" begin
+            @test ~DNA_Gap === DNA_N
+            @test ~DNA_N   === DNA_Gap
+            @test DNA_A | DNA_C === DNA_M
+            @test DNA_A & DNA_C === DNA_Gap
+            @test_throws Exception DNA_A & RNA_A
+            @test_throws Exception DNA_A | RNA_A
             @test DNA_Gap < DNA_A < DNA_C < DNA_G < DNA_T < DNA_N
             @test !(DNA_A > DNA_G)
             @test trailing_zeros(DNA_A) === 0
@@ -420,7 +426,11 @@ end
         @test !isvalid(AminoAcid, 0x1c)
     end
 
-    @testset "Arithmetic and Order" begin
+    @testset "Logic operations and Order" begin
+        @test ~RNA_Gap === RNA_N
+        @test ~RNA_N   === RNA_Gap
+        @test RNA_A | RNA_C === RNA_M
+        @test RNA_A & RNA_C === RNA_Gap
         @test (AA_A < AA_R < AA_N < AA_V < AA_O < AA_U <
                AA_B < AA_J < AA_Z < AA_X < AA_Term < AA_Gap)
         @test !(AA_J < AA_B)


### PR DESCRIPTION
As discussed on Slack

Currently, BioSymbols can be converted to integers:
```
julia> convert(Integer, DNA_M)
0x03
```

The problem with this is that `convert` is called automatically by Julia in many circumstances, which can lead to unexpected behaviour:
```
julia> a = dna"AAA"; a[1] = 3; a
3nt DNA Sequence:
MAA
```
The fact that `DNA_M` is internally stored as `0x03` is somewhat arbitrary implementation detail and should not be a part of the API for BioSymbols or BioSequences. Similarly, it's not entirely sensical why
```
julia> DNA_M + 1
DNA_G
```

In this PR, integer/biosymbol conversion and arithmetic is removed. This includes addition, subtraction, binary operations (`|`, `~` and `&`), and conversion.
* To get an integer from a biosymbol `x`, use `encoded_data(x)`.
* To get a biosymbol from an integer, use `encode(T, x)`.
* Any future BioSymbols that might not be implemented as primitive types should implement:
    *`encoded_data_eltype(::Type{T})`,
    *`encoded_data(x::T)`
    *`encode(::Type{T}, x)`
    The two latter methods fall back to using `reinterpret`.

Edit: This is very breaking and will with almost 100% certainty create problems for other BioJulia packages. I can fix those, if we agree this should be merged