### PR TITLE
Improve inferrability

### DIFF
--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -128,7 +128,7 @@ include("aminoacid.jl")
 
 Test if `symbol` is a gap.
 """
-isgap(symbol::BioSymbol) = symbol == gap(typeof(symbol))
+isgap(symbol::BioSymbol) = symbol === gap(typeof(symbol))
 
 
 # Arithmetic and Order

--- a/src/aminoacid.jl
+++ b/src/aminoacid.jl
@@ -13,7 +13,7 @@ primitive type AminoAcid <: BioSymbol 8 end
 
 prefix(::AminoAcid) = "AA"
 type_text(::AminoAcid) = "Amino Acid"
-isterm(symbol::AminoAcid) = symbol == AA_Term
+isterm(symbol::AminoAcid) = symbol === AA_Term
 bytemask(symbol::AminoAcid) = 0b11111
 
 
@@ -32,7 +32,7 @@ AminoAcid(nt::Integer) = convert(AminoAcid, nt)
 
 function Base.convert(::Type{AminoAcid}, c::Char)
     aa = tryparse(AminoAcid, c)
-    if aa == nothing
+    if aa === nothing
         throw(InexactError(:convert, AminoAcid, c))
     end
     return aa
@@ -229,7 +229,7 @@ end
 
 function Base.parse(::Type{AminoAcid}, c::Union{AbstractString,Char})
     aa = tryparse(AminoAcid, c)
-    if aa == nothing
+    if aa === nothing
         throw(ArgumentError("invalid amino acid"))
     end
     return aa


### PR DESCRIPTION
Replace a bunch of `==` with `===`. Seems trivial,  but it allows the compiler to infer the return type of things like `AminoAcid(::Char)`, which makes a difference.