### PR TITLE
Removed Automa parsing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,11 @@
 name = "BioSymbols"
 uuid = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 authors = ["Ben J. Ward <benjward@protonmail.com"]
-version = "4.0.4"
+version = "4.0.5"
 
 [deps]
-Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
 
 [compat]
-Automa = "0.8"
 julia = "1"
 
 [extras]

--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -99,8 +99,6 @@ export
     encoded_data,
     encode
 
-import Automa
-import Automa.RegExp: @re_str
 
 """
 The BioSymbol type is an abstract type that represents


### PR DESCRIPTION
Basically it's a large dependency for very little benefit. I'm not adament this should be removed, but I just don't see the need to parse three-letter amino acid sequences at high speed.