### PR TITLE
Add stringbyte function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,7 @@
 name = "BioSymbols"
 uuid = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 authors = ["Ben J. Ward <benjward@protonmail.com>"]
-version = "5.0.0"
-
-[deps]
+version = "5.1.0"
 
 [compat]
 julia = "1"

--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -144,7 +144,7 @@ julia> stringbyte(AA_Gap) == UInt8('-')
 true
 ```
 """
-stringbyte(x::BioSymbol) = UInt8(Char(x))
+function stringbyte end
 
 # Create a lookup table from biosymbol to the UInt8 for the character that would
 # represent it in a string, e.g. DNA_G -> UInt8('G')

--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -97,7 +97,8 @@ export
     compatbits,
     alphabet,
     encoded_data,
-    encode
+    encode,
+    stringbyte
 
 
 """
@@ -126,6 +127,42 @@ Base.broadcastable(x::BioSymbol) = (x,)
 
 include("nucleicacid.jl")
 include("aminoacid.jl")
+
+# Less efficient fallback. Should only be called for symbols of AsciiAlphabet
+"""
+	stringbyte(::BioSymbol)::UInt8
+
+For biosymbol types that can be represented as ASCII characters, `stringbyte(x)`
+returns the printable ASCII byte that represents the character in a string.
+
+# Examples
+```julia
+julia> stringbyte(DNA_A) == UInt8('A')
+true
+
+julia> stringbyte(AA_Gap) == UInt8('-')
+true
+```
+"""
+stringbyte(x::BioSymbol) = UInt8(Char(x))
+
+# Create a lookup table from biosymbol to the UInt8 for the character that would
+# represent it in a string, e.g. DNA_G -> UInt8('G')
+for alphabettype in ("DNA", "RNA", "AminoAcid")
+    tablename = Symbol(uppercase(alphabettype), "_TO_BYTE")
+    typ = Symbol(alphabettype)
+    @eval begin
+        const $(tablename) = let
+            alph = alphabet($(typ))
+            bytes = zeros(UInt8, length(alph))
+            @inbounds for letter in alph
+                bytes[reinterpret(UInt8, letter) + 1] = UInt8(Char(letter))
+            end
+            Tuple(bytes)
+        end
+        stringbyte(x::$(typ)) = @inbounds $(tablename)[reinterpret(UInt8, x) + 1]
+    end
+end
 
 """
     isgap(symbol::BioSymbol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,6 +89,14 @@ end
                 @test encoded_data(RNA_B)   === 0b1110
                 @test encoded_data(RNA_N)   === 0b1111
             end
+
+        	@testset "stringbyte" begin
+        		for T in (DNA, RNA)
+	        		@test all(alphabet(DNA)) do i
+	        			UInt8(Char(i)) == stringbyte(i)
+	  	      		end
+	        	end
+        	end
         end
 
         @testset "Char" begin
@@ -407,6 +415,12 @@ end
         @test_throws InexactError convert(AminoAcid, '\0')
         @test_throws InexactError convert(AminoAcid, '@')
         @test_throws InexactError convert(AminoAcid, '亜')
+    end
+
+    @testset "stringbyte" begin
+     	@test all(alphabet(AminoAcid)) do i
+     		UInt8(Char(i)) == stringbyte(i)
+     	end
     end
 
     @testset "isvalid" begin


### PR DESCRIPTION
This PR adds the `stringbyte` function. It effectively converts a biosymbol to the `UInt8` value that represents it in a `String`. It is not required to implement for all `BioSymbol`, since some `BioSymbol` may be represented by non-ASCII characters. The speed improvement over requiring a round-trip to `Char` is quite large.

Previously, this function was done in `BioSequences`, but I think it's nicer to have this functionality in this package, so I would like to move it to here.

If possible, I would like to make a 5.1.0 release for this and have BioSequences v3 depend on it.