### PR TITLE
Optimise hashing

### DIFF
--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -269,4 +269,11 @@ false
     return compatbits(x) & compatbits(y) != 0
 end
 
+# This function needs to be generated, because it looks the objectid of
+# the type of x up at compile time.
+@generated function Base.hash(x::BioSymbol, h::UInt)
+    # This actually looks up the hash of the TYPE of x, not of x
+    :(hash(encoded_data(x), h ⊻ $(hash(x))))
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -383,6 +383,12 @@ end
         @test ACGUN[5] === RNA_N
         @test collect(ACGUN) == [RNA_A, RNA_C, RNA_G, RNA_U, RNA_N]
     end
+
+    @testset "Hashing" begin
+        @test hash(DNA_A) != hash(RNA_A)
+        @test hash(DNA_A) != hash(DNA_G)
+        @test hash(DNA_W) == hash(DNA_W)
+    end
 end
 
 @testset "Aminoacids" begin
@@ -579,5 +585,13 @@ end
             @test tryparse(AminoAcid, '@') == nothing
             @test tryparse(AminoAcid, '亜') == nothing
         end
+    end
+
+    @testset "Hashing" begin
+        @test hash(AA_K) == hash(AA_K)
+        @test hash(AA_M) != hash(AA_Gap)
+        five = reinterpret(AminoAcid, 0x05)
+        @test hash(five) != hash(0x05)
+        @test hash(five) != hash(reinterpret(DNA, five))
     end
 end


### PR DESCRIPTION
Default implementation of Base.hash uses objectid, which is slow.
Use a new implementation which hashes the encoded data of biosymbols xor'd with
objectid of its type, the latter being looked up at compile time.
This causes nondeterministic behaviour of hashing between Julia sessions, but
I think that is fair game.

See also https://github.com/BioJulia/BioSequences.jl/issues/243