### PR TITLE
Add `gap(::Type{Char})` to prevent piracy from BioSequences.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioSymbols"
 uuid = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 authors = ["Ben J. Ward <benjward@protonmail.com>"]
-version = "5.1.1"
+version = "5.1.2"
 
 [deps]
 SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"

--- a/src/BioSymbols.jl
+++ b/src/BioSymbols.jl
@@ -190,6 +190,24 @@ Test if `symbol` is a gap.
 """
 isgap(symbol::BioSymbol) = symbol === gap(typeof(symbol))
 
+"""
+    gap(::Type{T})::T
+
+Return the gap (indel) representation of `T`.
+By default, `gap` is defined for `DNA`, `RNA`, `AminoAcid` and `Char`.
+
+# Examples
+```julia
+julia> gap(RNA)
+RNA_Gap
+
+julia> gap(Char)
+'-': ASCII/Unicode U+002D (category Pd: Punctuation, dash)
+```
+"""
+function gap end
+
+gap(::Type{Char}) = '-'
 
 # Arithmetic and Order
 # --------------------

--- a/src/aminoacid.jl
+++ b/src/aminoacid.jl
@@ -192,11 +192,6 @@ function iscertain(aa::AminoAcid)
     return AA_A ≤ aa ≤ AA_U || aa == AA_Term
 end
 
-"""
-    gap(AminoAcid)
-
-Return `AA_Gap`.
-"""
 gap(::Type{AminoAcid}) = AA_Gap
 
 """

--- a/src/nucleicacid.jl
+++ b/src/nucleicacid.jl
@@ -354,18 +354,7 @@ julia> ACGUN
 """
 const ACGUN = (RNA_A, RNA_C, RNA_G, RNA_U, RNA_N)
 
-"""
-    gap(DNA)
-
-Return `DNA_Gap`.
-"""
 gap(::Type{DNA}) = DNA_Gap
-
-"""
-    gap(RNA)
-
-Return `RNA_Gap`.
-"""
 gap(::Type{RNA}) = RNA_Gap
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,6 +227,8 @@ end
         end
     end
 
+    @test gap(Char) === '-'
+
     @testset "isterm" begin
         for nt in alphabet(DNA)
             @test BioSymbols.isterm(nt) === false


### PR DESCRIPTION
Currently, `BioSequences` defines this method, which is piracy. We might as well define it here.